### PR TITLE
Make Glyph Records glyph name column resizable

### DIFF
--- a/FeaturePreview.roboFontExt/info.plist
+++ b/FeaturePreview.roboFontExt/info.plist
@@ -32,13 +32,13 @@
 	<key>timeStamp</key>
 	<real>1331630446.5935349</real>
 	<key>version</key>
-	<string>1.1</string>
+	<string>1.2</string>
 	<key>com.robofontmechanic.Mechanic</key>
 	<dict>
 		<key>repository</key>
 		<string>typemytype/featurePreviewRoboFontExtension</string>
 		<key>summary</key>
-		<string>Preview features, previously know as Area51.</string>
+		<string>Preview OpenType features.</string>
 	</dict>
 </dict>
 </plist>

--- a/FeaturePreview.roboFontExt/lib/featurePreview.py
+++ b/FeaturePreview.roboFontExt/lib/featurePreview.py
@@ -45,12 +45,12 @@ class FeatureTester(BaseWindowController):
         self.w.previewTabs[0].lineView = self.glyphLineView = GlyphLineView((0, 0, -0, -0), showPointSizePlacard=True)
         # records
         columnDescriptions = [
-            dict(title="Name", width=100),
+            dict(title="Name", width=100, minWidth=100, maxWidth=300),
             dict(title="XP", width=50),
             dict(title="YP", width=50),
             dict(title="XA", width=50),
             dict(title="YA", width=50),
-            dict(title="Alternates", width=100)
+            dict(title="Alternates", width=100, minWidth=100, maxWidth=300)
         ]
         self.w.previewTabs[1].recordsList = self.glyphRecordsList = List((0, 0, -0, -0), [], columnDescriptions=columnDescriptions,
                 showColumnTitles=True, drawVerticalLines=True, drawFocusRing=False)

--- a/FeaturePreview.roboFontExt/lib/featurePreview.py
+++ b/FeaturePreview.roboFontExt/lib/featurePreview.py
@@ -18,7 +18,7 @@ class FeatureTester(BaseWindowController):
 
     def __init__(self, font):
         if font is None:
-            print "A open UFO is needed"
+            print "An open UFO is needed"
             return
         roboFabFont = font
         font = font.naked()


### PR DESCRIPTION
Make Glyph Records glyph name column resizable to make it usable for longer glyph names.